### PR TITLE
Refactored the output of allCarsUsage

### DIFF
--- a/src/car/car.controller.ts
+++ b/src/car/car.controller.ts
@@ -1,7 +1,8 @@
-import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe, Query, UsePipes, ValidationPipe } from '@nestjs/common';
 
 import { ReservationService } from 'src/reservation/reservation.service';
 import { CarService } from './car.service';
+import { DateQueryDto } from './dto/dateQuery.dto';
 
 @Controller('car')
 export class CarController {
@@ -18,8 +19,9 @@ export class CarController {
     }
 
     @Get('usage/all')
-    async getAllCarsUsage(): Promise<object> {
-        return await this.carService.getAllCarsUsage();
+    @UsePipes(new ValidationPipe({ transform: true }))
+    async getAllCarsUsage(@Query() dateQueryDto?: DateQueryDto): Promise<object> {
+        return await this.carService.getAllCarsUsage(dateQueryDto);
     }
 
     @Get('usage/:id')

--- a/src/car/dto/dateQuery.dto.ts
+++ b/src/car/dto/dateQuery.dto.ts
@@ -1,0 +1,14 @@
+import { Type } from 'class-transformer';
+import { IsDate, IsOptional } from 'class-validator';
+
+export class DateQueryDto {
+    @IsOptional()
+    @IsDate()
+    @Type(() => Date)
+    dateFrom?: Date;
+
+    @IsOptional()
+    @IsDate()
+    @Type(() => Date)
+    dateTo?: Date;
+}


### PR DESCRIPTION
The output of the "getAllCarsUsage" which generates a report of all the car reservations, has been changed to the following format:
{
    month: {
        car id: {
            reservation_id,
            name,
            license_plate,
            days,
            count
        }
    }
}
![image](https://user-images.githubusercontent.com/124992083/220340599-661848dd-5a9e-4349-894a-488ce05315e7.png)